### PR TITLE
Add optional edge identifiers

### DIFF
--- a/schema/pg-json.json
+++ b/schema/pg-json.json
@@ -26,6 +26,9 @@
       "items": {
         "type": "object",
         "properties": {
+          "id": {
+            "$ref": "#/$defs/id"
+          },
           "from": {
             "$ref": "#/$defs/id"
           },
@@ -48,7 +51,6 @@
     }
   },
   "required": [ "nodes", "edges" ],
-  "required": [ "nodes","edges" ],
   "additionalProperties": false,
   "$defs": {
     "id": {

--- a/schema/pg-jsonl.json
+++ b/schema/pg-jsonl.json
@@ -24,6 +24,9 @@
         "type": {
           "const": "edge"
         },
+        "id": {
+          "$ref": "#/$defs/id"
+        },
         "from": {
           "$ref": "#/$defs/id"
         },


### PR DESCRIPTION
As discussed at https://github.com/orgs/pg-format/discussions/34

Implemented in pgraphs 0.6.0 but repeated edge ids are not detected yet.